### PR TITLE
Fixing and improving decoding of web socket frames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.ws.spec.version>0.24</nukleus.ws.spec.version>
+    <nukleus.ws.spec.version>develop-SNAPSHOT</nukleus.ws.spec.version>
     <reaktor.version>0.39</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.ws.spec.version>develop-SNAPSHOT</nukleus.ws.spec.version>
+    <nukleus.ws.spec.version>0.25</nukleus.ws.spec.version>
     <reaktor.version>0.41</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
@@ -393,7 +393,7 @@ public final class ServerStreamFactory implements StreamFactory
                 int length = payload.sizeof();
                 while (length > 0)
                 {
-                    int consumed = decodeState.decode(dataRO.buffer(), offset, payload.sizeof());
+                    int consumed = decodeState.decode(dataRO.buffer(), offset, length);
                     offset += consumed;
                     length -= consumed;
                 }

--- a/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
@@ -71,6 +71,8 @@ public final class ServerStreamFactory implements StreamFactory
     private static final String WEBSOCKET_VERSION_13 = "13";
     private static final int MAXIMUM_HEADER_SIZE = 14;
 
+    private static final DirectBuffer CLOSE_PAYLOAD = new UnsafeBuffer(new byte[0]);
+
     private final MessageDigest sha1 = initSHA1();
 
     private final RouteFW routeRO = new RouteFW();
@@ -891,7 +893,7 @@ public final class ServerStreamFactory implements StreamFactory
         private void handleEnd(
             EndFW end)
         {
-            payload.wrap(new UnsafeBuffer(new byte[0]), 0, 0);
+            payload.wrap(CLOSE_PAYLOAD, 0, 0);
             doHttpData(acceptReply, acceptReplyId, acceptReplyPadding, payload, 0x88);
             doHttpEnd(acceptReply, acceptReplyId);
         }

--- a/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
@@ -891,6 +891,8 @@ public final class ServerStreamFactory implements StreamFactory
         private void handleEnd(
             EndFW end)
         {
+            payload.wrap(new UnsafeBuffer(new byte[0]), 0, 0);
+            doHttpData(acceptReply, acceptReplyId, acceptReplyPadding, payload, 0x88);
             doHttpEnd(acceptReply, acceptReplyId);
         }
 

--- a/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/ws/internal/stream/ServerStreamFactory.java
@@ -445,6 +445,7 @@ public final class ServerStreamFactory implements StreamFactory
         private int assembleHeader(DirectBuffer buffer, int offset, int length)
         {
             int remaining = Math.min(length, MAXIMUM_HEADER_SIZE - headerLength);
+            // may copy more than actual header length (up to max header length), but will adjust at the end
             header.putBytes(headerLength, buffer, offset, remaining);
 
             int consumed = remaining;
@@ -1158,16 +1159,6 @@ public final class ServerStreamFactory implements StreamFactory
             LangUtil.rethrowUnchecked(ex);
             return null;
         }
-    }
-
-    public static void print(String str, DirectBuffer buffer, int offset, int length)
-    {
-        System.out.printf("------- %s offset=%d length=%d\n", str, offset, length);
-        for(int i=0; i < length; i++)
-        {
-            System.out.printf("%02x ", buffer.getByte(offset + i));
-        }
-        System.out.println("\n--------");
     }
 
     @FunctionalInterface

--- a/src/main/java/org/reaktivity/nukleus/ws/internal/types/codec/WsHeaderFW.java
+++ b/src/main/java/org/reaktivity/nukleus/ws/internal/types/codec/WsHeaderFW.java
@@ -119,7 +119,6 @@ public final class WsHeaderFW extends Flyweight
         }
 
         return wsFrameLength <= maxLength;
-
     }
 
     @Override

--- a/src/test/java/org/reaktivity/nukleus/ws/internal/streams/server/ClosingHandshakeIT.java
+++ b/src/test/java/org/reaktivity/nukleus/ws/internal/streams/server/ClosingHandshakeIT.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.ws.internal.streams.server;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+/**
+ * RFC-6455, section 5.2 "Base Framing Protocol"
+ */
+public class ClosingHandshakeIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/ws/control/route")
+            .addScriptRoot("client", "org/reaktivity/specification/ws/closing")
+            .addScriptRoot("server", "org/reaktivity/specification/nukleus/ws/streams/closing")
+            // TODO: remove the following when all tests have been completed
+            .addScriptRoot("streams", "org/reaktivity/specification/ws/closing");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024)
+        .nukleus("ws"::equals)
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
+            "${client}/client.send.empty.close.frame/handshake.request.and.frame",
+            "${server}/client.send.empty.close.frame/handshake.response.and.frame" })
+    public void shouldCompleteCloseHandshakeWhenClientSendEmptyCloseFrame()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "${route}/server/controller",
+            "${client}/client.send.close.frame.with.code.1005/handshake.request.and.frame",
+            "${server}/client.send.close.frame.with.code.1005/handshake.response.and.frame" })
+    public void shouldCompleteCloseHandshakeWhenClientSendCloseFrameWithCode1005()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+}


### PR DESCRIPTION
- decoderState unwinds the call stack and calls the next decoderState
- Slots are not used as the max header size is only 14 bytes
- Previously once the slot is used, the rest of the decoding continued to use the slot.
  Now exact header length bytes are assembled. After header is decoded, payload
  doesn't require any slot anymore
- END frame writes websocket close frame
- Unmasking the close frame payload before getting the status code